### PR TITLE
Fix render

### DIFF
--- a/src/ClassicMain.jsx
+++ b/src/ClassicMain.jsx
@@ -31,8 +31,6 @@ export const ClassicMain = () => {
 			.catch((err) => {
 				console.log(err.message);
 			});
-
-		continueRender(handle);
 	}, [handle]);
 
 	useEffect(() => {
@@ -162,6 +160,7 @@ export const ClassicMain = () => {
 		// }
 
 		setClassicData(data);
+		continueRender(handle);
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
Your render depends on asynchronous data fetching. While delayRender() and continueRender() was used, continueRender() was called before all data fetching was done.

I fixed the logic in this PR. See also here for how to correctly implement it: https://www.remotion.dev/docs/delay-render